### PR TITLE
adds support for setting use-file on FormatterElement

### DIFF
--- a/src/lein_junit/core.clj
+++ b/src/lein_junit/core.clj
@@ -65,11 +65,12 @@
   [type & [use-file]]
   (doto (FormatterElement.)
     (.setClassname (.getName (junit-formatter-class type)))
-    (.setUseFile false)))
+    (.setUseFile (lancet/coerce Boolean/TYPE (or use-file "off")))))
 
 (defn extract-formatter
   "Extract the Junit formatter element from the project."
-  [project] (junit-formatter-element (or (:junit-formatter project) :brief)))
+  [project] (junit-formatter-element (or (:junit-formatter project) :brief)
+                                     (or (:junit-formatter-use-file project) "off")))
 
 (defn junit-options
   "Returns the JUnit options of the project."

--- a/test/lein_junit/test/core.clj
+++ b/test/lein_junit/test/core.clj
@@ -45,6 +45,21 @@
        :brief :plain :summary :xml
        "brief" "plain" "summary" "xml"))
 
+(deftest test-junit-extract-formatter
+  ;; FormatterElement.getUseFile is declared package private, so we
+  ;; need to make it accessible before we can invoke it.
+  (let [call-get-use-file (fn [obj]
+                              (-> FormatterElement (.getDeclaredMethod (name "getUseFile")
+                                                            (into-array Class nil))
+                                  (doto (.setAccessible true))
+                                  (.invoke obj (into-array Object nil))))
+        with-file (junit-formatter-element :plain "on")
+        without-file (junit-formatter-element :plain "off")
+        formatter-file-off-by-default (junit-formatter-element :plain)]
+    (is (call-get-use-file with-file) true)
+    (is (call-get-use-file without-file) false)
+    (is (call-get-use-file formatter-file-off-by-default) false)))
+
 (deftest test-extract-task
   (let [task (extract-task project)]
     (is (isa? (class task) JUnitTask)))


### PR DESCRIPTION
To enable add ':junit-formatter-use-file "on"' to your project.clj file
