### PR TITLE
Expose use-file option through a project.clj keyword

### DIFF
--- a/src/lein_junit/core.clj
+++ b/src/lein_junit/core.clj
@@ -65,11 +65,12 @@
   [type & [use-file]]
   (doto (FormatterElement.)
     (.setClassname (.getName (junit-formatter-class type)))
-    (.setUseFile false)))
+    (.setUseFile (lancet/coerce Boolean/TYPE (or use-file "off")))))
 
 (defn extract-formatter
   "Extract the Junit formatter element from the project."
-  [project] (junit-formatter-element (or (:junit-formatter project) :brief)))
+  [project] (junit-formatter-element (or (:junit-formatter project) :brief)
+                                     (or (:junit-formatter-use-file project) "off")))
 
 (defn junit-options
   "Returns the JUnit options of the project."

--- a/src/lein_junit/core.clj
+++ b/src/lein_junit/core.clj
@@ -11,7 +11,8 @@
            [org.apache.tools.ant.types FileSet Path]
            [org.apache.tools.ant.taskdefs.optional.junit
             BriefJUnitResultFormatter FormatterElement SummaryJUnitResultFormatter
-            PlainJUnitResultFormatter XMLJUnitResultFormatter]))
+            PlainJUnitResultFormatter XMLJUnitResultFormatter JUnitTask$SummaryAttribute]
+))
 
 (def ^{:dynamic true} *junit-options*
   {:fork "on" :haltonerror "off" :haltonfailure "off"})
@@ -114,9 +115,17 @@
   "Run the Java test via JUnit."
   [project & selectors]
   (javac project)
-  (let [junit-task (apply extract-task project selectors)]
+  (let [junit-task (apply extract-task project selectors)
+        summary ()]
     (.setErrorProperty junit-task "lein-junit.errors")
     (.setFailureProperty junit-task "lein-junit.failures")
+
+    (if (:junit-formatter-use-file project)
+      (do
+        (let [summary-attribute (JUnitTask$SummaryAttribute.)]
+          (.setValue summary-attribute "withOutAndErr")
+          (.setPrintsummary junit-task summary-attribute))))
+
     (.execute junit-task)
     (if (or (.getProperty lancet/ant-project "lein-junit.errors")
             (.getProperty lancet/ant-project "lein-junit.failures"))

--- a/test/lein_junit/test/core.clj
+++ b/test/lein_junit/test/core.clj
@@ -53,12 +53,12 @@
                                                             (into-array Class nil))
                                   (doto (.setAccessible true))
                                   (.invoke obj (into-array Object nil))))
-        with-file (junit-formatter-element :plain "on")
-        without-file (junit-formatter-element :plain "off")
+        with-use-file (junit-formatter-element :plain "on")
+        without-use-file (junit-formatter-element :plain "off")
         formatter-file-off-by-default (junit-formatter-element :plain)]
-    (is (call-get-use-file with-file) true)
-    (is (call-get-use-file without-file) false)
-    (is (call-get-use-file formatter-file-off-by-default) false)))
+    (is (= (call-get-use-file with-use-file) true))
+    (is (= (call-get-use-file without-use-file) false))
+    (is (= (call-get-use-file formatter-file-off-by-default) false))))
 
 (deftest test-extract-task
   (let [task (extract-task project)]

--- a/test/lein_junit/test/core.clj
+++ b/test/lein_junit/test/core.clj
@@ -45,6 +45,21 @@
        :brief :plain :summary :xml
        "brief" "plain" "summary" "xml"))
 
+(deftest test-junit-extract-formatter
+  ;; FormatterElement.getUseFile is declared package private, so we
+  ;; need to make it accessible before we can invoke it.
+  (let [call-get-use-file (fn [obj]
+                              (-> FormatterElement (.getDeclaredMethod (name "getUseFile")
+                                                            (into-array Class nil))
+                                  (doto (.setAccessible true))
+                                  (.invoke obj (into-array Object nil))))
+        with-file (junit-formatter-element :plain "on")
+        without-file (junit-formatter-element :plain "off")
+        formatter-file-off-by-default (junit-formatter-element :plain)]
+    (is (call-get-use-file with-file) true)
+    (is (call-get-use-file without-file) false)
+    (is (call-get-use-file formatter-file-off-by-default) false)))
+
 (deftest test-extract-task
   (let [task (extract-task project)]
     (is (isa? (class task) JUnitTask)))


### PR DESCRIPTION
Makes it possible to write test results to a file instead of stdout. Useful if you plan to integrate the results on a CI server that supports junit xml output.

To use, add this to project.clj

  :junit-formatter :xml
  :junit-formatter-use-file "on"

If :junit-formatter-use-file is set to on, JUnitTask.setPrintSummary will be set to "withOutAndErr" so you still get useful output when running from the commandline.
