### PR TITLE
Accept additional JVM options: `:lein-junit :jvm-opts`

### DIFF
--- a/src/lein_junit/core.clj
+++ b/src/lein_junit/core.clj
@@ -98,7 +98,8 @@
 (defn configure-jvm-args
   "Configure the JVM arguments for the JUnit task."
   [project junit-task]
-  (doseq [arg (@#'leiningen.core.eval/get-jvm-args project)]
+  (doseq [arg (concat (@#'leiningen.core.eval/get-jvm-args project)
+                      (get-in project [:lein-junit :jvm-opts]))]
     (when-not (re-matches #"^-Xbootclasspath.+" arg)
       (.setValue (.createJvmarg junit-task) arg))))
 


### PR DESCRIPTION
This could not be added to :junit-options, since that is restricted to
the schema of some Ant task.
