### PR TITLE
Fixed the compiled pattern error in Windows.

### DIFF
--- a/src/lein_junit/core.clj
+++ b/src/lein_junit/core.clj
@@ -20,7 +20,7 @@
   (Path. lancet/ant-project str))
 
 (defn selector-pattern [selector]
-  (re-pattern (str (replace selector "." File/separator) ".*")))
+  (re-pattern (str (replace selector \. \/) ".*")))
 
 (defn find-testcases
   "Returns the class filesnames of the project's Junit test cases."
@@ -29,7 +29,8 @@
         file (file-seq (file (:root project) path))
         :when (and (not (.isDirectory file))
                    (re-matches #".*Test\.java" (str file)))]
-    (-> (replace (str file) (re-pattern (str ".*" File/separator path File/separator)) "")
+    (-> (replace (str file) File/separatorChar \/)
+        (replace (re-pattern (str ".*/" path "/")) "")
         (replace #"\.java" ".class"))))
 
 (defn select-testcases


### PR DESCRIPTION
In Windows, I have an error as following:

```
java.util.regex.PatternSyntaxException: Unexpected internal error near index 17
.*\src/test/java\
                 ^
        at java.util.regex.Pattern.error(Pattern.java:1955)
        at java.util.regex.Pattern.compile(Pattern.java:1702)
        at java.util.regex.Pattern.<init>(Pattern.java:1351)
        at java.util.regex.Pattern.compile(Pattern.java:1028)
        at clojure.core$re_pattern.invoke(core.clj:4377)
        at lein_junit.core$find_testcases$iter__1054__1060$fn__1061$iter__1056__1062$fn__1063.invoke(core.clj:32)
        at clojure.lang.LazySeq.sval(LazySeq.java:42)
        at clojure.lang.LazySeq.seq(LazySeq.java:60)
        at clojure.lang.RT.seq(RT.java:484)
        at clojure.core$seq.invoke(core.clj:133)
        at lein_junit.core$find_testcases$iter__1054__1060$fn__1061.invoke(core.clj:29)
        at clojure.lang.LazySeq.sval(LazySeq.java:42)
        at clojure.lang.LazySeq.seq(LazySeq.java:60)
        at clojure.lang.RT.seq(RT.java:484)
        at clojure.core$seq.invoke(core.clj:133)
        at clojure.core$filter$fn__4226.invoke(core.clj:2523)
        at clojure.lang.LazySeq.sval(LazySeq.java:42)
        at clojure.lang.LazySeq.seq(LazySeq.java:60)
        at clojure.lang.RT.seq(RT.java:484)
        at clojure.core$seq.invoke(core.clj:133)
        at clojure.core$map$fn__4207.invoke(core.clj:2479)
        at clojure.lang.LazySeq.sval(LazySeq.java:42)
        at clojure.lang.LazySeq.seq(LazySeq.java:60)
        at clojure.lang.RT.seq(RT.java:484)
        at clojure.core$seq.invoke(core.clj:133)
        at clojure.core$empty_QMARK_.invoke(core.clj:5595)
        at lein_junit.core$testcase_fileset.doInvoke(core.clj:47)
        at clojure.lang.RestFn.invoke(RestFn.java:410)
        at clojure.lang.AFn.applyToHelper(AFn.java:161)
        at clojure.lang.RestFn.applyTo(RestFn.java:132)
        at clojure.core$apply.invoke(core.clj:619)
        at lein_junit.core$extract_task.doInvoke(core.clj:113)
        at clojure.lang.RestFn.invoke(RestFn.java:410)
        at clojure.lang.AFn.applyToHelper(AFn.java:161)
        at clojure.lang.RestFn.applyTo(RestFn.java:132)
        at clojure.core$apply.invoke(core.clj:619)
        at lein_junit.core$junit.doInvoke(core.clj:122)
        at clojure.lang.RestFn.invoke(RestFn.java:410)
        at clojure.lang.AFn.applyToHelper(AFn.java:161)
        at clojure.lang.RestFn.applyTo(RestFn.java:132)
        at clojure.core$apply.invoke(core.clj:619)
        at leiningen.junit$junit.doInvoke(junit.clj:7)
        at clojure.lang.RestFn.invoke(RestFn.java:410)
        at clojure.lang.Var.invoke(Var.java:415)
        at clojure.lang.AFn.applyToHelper(AFn.java:161)
        at clojure.lang.Var.applyTo(Var.java:532)
        at clojure.core$apply.invoke(core.clj:619)
        at leiningen.core.main$resolve_task$fn__3029.doInvoke(main.clj:189)
        at clojure.lang.RestFn.invoke(RestFn.java:410)
        at clojure.lang.AFn.applyToHelper(AFn.java:161)
        at clojure.lang.RestFn.applyTo(RestFn.java:132)
        at clojure.lang.AFunction$1.doInvoke(AFunction.java:29)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.core$apply.invoke(core.clj:619)
        at leiningen.core.main$apply_task.invoke(main.clj:230)
        at leiningen.core.main$resolve_and_apply.invoke(main.clj:234)
        at leiningen.core.main$_main$fn__3092.invoke(main.clj:303)
        at leiningen.core.main$_main.doInvoke(main.clj:290)
        at clojure.lang.RestFn.invoke(RestFn.java:408)
        at clojure.lang.Var.invoke(Var.java:415)
        at clojure.lang.AFn.applyToHelper(AFn.java:161)
        at clojure.lang.Var.applyTo(Var.java:532)
        at clojure.core$apply.invoke(core.clj:617)
        at clojure.main$main_opt.invoke(main.clj:335)
        at clojure.main$main.doInvoke(main.clj:440)
        at clojure.lang.RestFn.invoke(RestFn.java:436)
        at clojure.lang.Var.invoke(Var.java:423)
        at clojure.lang.AFn.applyToHelper(AFn.java:167)
        at clojure.lang.Var.applyTo(Var.java:532)
        at clojure.main.main(main.java:37)
```

This error caused by the file separator '\'. So I fixed it. 
