### PR TITLE
Feature/cli specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,30 @@ A Leiningen plugin that runs Java tests via JUnit.
 
 Via Clojars: http://clojars.org/lein-junit
 
+## Configuration
+
+The following options are accepted in `defproject`:
+- `:junit-formatter`: keyword or string arg, can be `:brief` (default), `:plain`, `:xml`, or `:summary`
+- `:junit-results-dir`: output folder for test results. If unset, outputs to standard out
+- `:junit-test-file-pattern`: regex pattern used to match tests. Defaults to `#".*Test\.java"`
+
+These arguments are acceptable on the CLI as well, and can be given with or without the leading ":".
+
 ## Example Configuration
 
-    (defproject sample-project "0.0.1-SNAPSHOT"
-      :min-lein-version "2.0.0"
-      :dependencies [[org.clojure/clojure "1.6.0"]]
-      :profiles {:dev {:dependencies [[junit/junit "4.11"]]}}
-      :plugins [[lein-junit "1.1.8"]]
-      :source-paths ["src/clojure"]
-      :java-source-paths ["src/java" "test/java"]
-      :junit ["test/java"]
-      :jvm-opts ["-XX:MaxPermSize=128m"])
+```clojure
+(defproject sample-project "0.0.1-SNAPSHOT"
+  :min-lein-version "2.0.0"
+  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :profiles {:dev {:dependencies [[junit/junit "4.11"]]}}
+  :plugins [[lein-junit "1.1.8"]]
+  :source-paths ["src/clojure"]
+  :java-source-paths ["src/java" "test/java"]
+  :junit ["test/java"]
+  :junit-formatter :plain
+  :junit-results-dir "test-results"
+  :jvm-opts ["-XX:MaxPermSize=128m"])
+```
 
 ## Usage
 
@@ -24,9 +37,16 @@ Run all junit tests.
 
     lein junit
 
+
 Run all junit tests matching a pattern.
 
     lein junit com.example
+
+
+Run all junit tests matching a paterrn, outputting XML results to "test-results"
+
+    lein junit :junit-formatter xml :junit-results-dir test-results com.example
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ These arguments are acceptable on the CLI as well, and can be given with or with
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.6.0"]]
   :profiles {:dev {:dependencies [[junit/junit "4.11"]]}}
-  :plugins [[lein-junit "1.1.8"]]
+  :plugins [[lein-junit "1.1.9-SNAPSHOT"]]
   :source-paths ["src/clojure"]
   :java-source-paths ["src/java" "test/java"]
   :junit ["test/java"]
@@ -37,13 +37,11 @@ Run all junit tests.
 
     lein junit
 
-
 Run all junit tests matching a pattern.
 
     lein junit com.example
 
-
-Run all junit tests matching a paterrn, outputting XML results to "test-results"
+Run all junit tests matching a paterrn, outputting XML results to "test-results/"
 
     lein junit :junit-formatter xml :junit-results-dir test-results com.example
 

--- a/src/lein_junit/task_args.clj
+++ b/src/lein_junit/task_args.clj
@@ -1,0 +1,30 @@
+(ns lein-junit.task-args
+  (:require [clojure.string :refer [join]]))
+
+
+(def ^:const arg-keys
+  #{:junit-formatter :junit-results-dir :junit-test-file-pattern})
+
+(defn keywordify-args [task-args]
+  (mapv (fn [token]
+          (if (= \: (first token))
+            (keyword (join (rest token)))
+            token))
+        task-args))
+
+(defn parse-task-args
+  [project task-args]
+  (let [options (select-keys project arg-keys)
+        task-args (keywordify-args task-args)
+        parsed-args {:options options :selectors []}
+        opt-key (volatile! nil)]
+    (reduce (fn [parsed-args token]
+              (cond
+               (contains? arg-keys token) (do (vreset! opt-key token)
+                                              parsed-args)
+               @opt-key (let [opt-key-val @opt-key]
+                          (vreset! opt-key nil)
+                          (assoc-in parsed-args [:options opt-key-val] token))
+               :else (update parsed-args :selectors conj token)))
+            parsed-args
+            task-args)))

--- a/test/lein_junit/test/core.clj
+++ b/test/lein_junit/test/core.clj
@@ -116,13 +116,18 @@
 (deftest test-parse-task-arg-options
   (let [basic-args [":junit-formatter" "brief"]]
     (is (= (:options (parse-task-args {} basic-args)) {:junit-formatter "brief"})))
-  (let [basic-args [":junit-formatter" ":brief"]]
-    (is (= (:options (parse-task-args {} basic-args)) {:junit-formatter :brief})))
-  (let [kw-args [":junit-formatter" "plain"]]
-    (is (= (:options (parse-task-args {} kw-args)) {:junit-formatter "plain"})))
+  (let [basic-args [":junit-formatter" "plain"]]
+    (is (= (:options (parse-task-args {} basic-args)) {:junit-formatter "plain"})))
+  (let [kw-args [":junit-formatter" ":brief"]]
+    (is (= (:options (parse-task-args {} kw-args)) {:junit-formatter :brief})))
   (let [project {:junit-results-dir "."}
-        kw-args [":junit-formatter" ":summary"]]
-    (is (= (:options (parse-task-args project kw-args)) {:junit-results-dir "." :junit-formatter :summary})))
+        merge-args [":junit-formatter" ":summary"]]
+    (is (= (:options (parse-task-args project merge-args)) {:junit-results-dir "." :junit-formatter :summary})))
   (let [project {:junit-formatter :plain}
-        kw-args [":junit-formatter" "xml"]]
-    (is (= (:options (parse-task-args project kw-args)) {:junit-formatter "xml"}))))
+        override-args [":junit-formatter" "xml"]]
+    (is (= (:options (parse-task-args project override-args)) {:junit-formatter "xml"}))))
+
+(deftest test-parse-task-args
+  (let [args ["test-pattern" ":junit-formatter" "brief" "test-pattern2"]]
+    (is (= (parse-task-args {} args) {:options {:junit-formatter "brief"}
+                                      :selectors ["test-pattern" "test-pattern2"]}))))


### PR DESCRIPTION
Add support for reading options from the CLI, which overrides what is found in `project.clj`.

Useful for projects where you often need to run in two modes, e.g. one behavior when testing locally and another when running in a CI environment